### PR TITLE
[FIX] Remove deprecated XML declarations in HTML description

### DIFF
--- a/purchase_location_by_line/static/description/index.html
+++ b/purchase_location_by_line/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>


### PR DESCRIPTION
Affected project `kemek` on `purchase_location_by_line` module

https://github.com/versada/monodoo/issues/1287